### PR TITLE
add check for ELECTRON_RUN_AS_NODE

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,5 +48,6 @@ function matchBuild (name) {
 
 function isElectron () {
   if (process.versions && process.versions.electron) return true
+  if (process.env.ELECTRON_RUN_AS_NODE) return true
   return typeof window !== 'undefined' && window.process && window.process.type === 'renderer'
 }


### PR DESCRIPTION
when you fork a proc in electron, this will help node-gyp-build detect that it's still in electron