### PR TITLE
Enable building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var binding = require('node-gyp-build')(__dirname)
 If you do these two things and bundle prebuilds [prebuildify](https://github.com/mafintosh/prebuildify) your native module will work for most platforms
 without having to compile on install time AND will work in both node and electron without the need to recompile between usage.
 
-You can override `node-gyp-build` and force compiling by doing `npm install --build-from-source`.
+Users can override `node-gyp-build` and force compiling by doing `npm install --build-from-source`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ var binding = require('node-gyp-build')(__dirname)
 If you do these two things and bundle prebuilds [prebuildify](https://github.com/mafintosh/prebuildify) your native module will work for most platforms
 without having to compile on install time AND will work in both node and electron without the need to recompile between usage.
 
+You can override `node-gyp-build` and force compiling by doing `npm install --build-from-source`.
+
 ## License
 
 MIT

--- a/bin.js
+++ b/bin.js
@@ -16,11 +16,10 @@ function buildFromSource () {
   if (!process.env.npm_config_argv) return false
 
   try {
-    var npmArgv = JSON.parse(process.env.npm_config_argv).cooked
-    return npmArgv.indexOf('--build-from-source') !== -1
-  } catch (_) { }
-
-  return false
+    return JSON.parse(process.env.npm_config_argv).cooked.indexOf('--build-from-source') !== -1
+  } catch (_) {
+    return false
+  }
 }
 
 function build () {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path')
 var os = require('os')
 
 // Workaround to fix webpack's build warnings: 'the request of a dependency is an expression'
-var runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require
+var runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require // eslint-disable-line
 
 var abi = process.versions.modules // TODO: support old node where this is undef
 var runtime = isElectron() ? 'electron' : 'node'


### PR DESCRIPTION
This enables the user to override and do `npm i --build-from-source`.

Closes https://github.com/Level/leveldown/issues/566