### PR TITLE
Optionally support prebuilds for libc and arm flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ without having to compile on install time AND will work in both node and electro
 
 Users can override `node-gyp-build` and force compiling by doing `npm install --build-from-source`.
 
+## Supported prebuild names
+
+If so desired you can bundle more specific flavors, for example `musl` builds to support Alpine, or targeting a numbered ARM architecture version.
+
+These prebuilds can be bundled in addition to generic prebuilds; `node-gyp-build` will try to find the most specific flavor first. In order of precedence:
+
+- If `arch` is `'arm'` or `'arm64'`:
+  - `${platform}${libc}-${arch}-v${arm_version}`
+  - `${platform}-${arch}-v${arm_version}`
+- `${platform}${libc}-${arch}`
+- `${platform}-${arch}`
+
+The `libc` flavor and `arm_version` are auto-detected but can be overridden through the `LIBC` and `ARM_VERSION` environment variables, respectively.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var fs = require('fs')
 var path = require('path')
 var os = require('os')
-var detectLibc = require('detect-libc')
 
 // Workaround to fix webpack's build warnings: 'the request of a dependency is an expression'
 var runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require // eslint-disable-line
@@ -10,7 +9,7 @@ var abi = process.versions.modules // TODO: support old node where this is undef
 var runtime = isElectron() ? 'electron' : 'node'
 var arch = os.arch()
 var platform = os.platform()
-var libc = process.env.LIBC || detectLibc.family || ''
+var libc = process.env.LIBC || (isAlpine(platform) ? 'musl' : 'glibc')
 var armv = process.env.ARM_VERSION || (arch === 'arm64' ? '8' : process.config.variables.arm_version) || ''
 
 module.exports = load
@@ -87,4 +86,8 @@ function isElectron () {
   if (process.versions && process.versions.electron) return true
   if (process.env.ELECTRON_RUN_AS_NODE) return true
   return typeof window !== 'undefined' && window.process && window.process.type === 'renderer'
+}
+
+function isAlpine (platform) {
+  return platform === 'linux' && fs.existsSync('/etc/alpine-release')
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "node-gyp-build-optional": "./optional.js",
     "node-gyp-build-test": "./build-test.js"
   },
+  "dependencies": {
+    "detect-libc": "~1.0.3"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mafintosh/node-gyp-build.git"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "node-gyp-build-optional": "./optional.js",
     "node-gyp-build-test": "./build-test.js"
   },
-  "dependencies": {
-    "detect-libc": "~1.0.3"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mafintosh/node-gyp-build.git"


### PR DESCRIPTION
This is:

1. An alternative to #9 (to support rolftimmermans/zeromq-ng#46 and https://github.com/Level/leveldown/issues/388), with the same naming scheme. Both these solutions are backwards compatible, except that #9 isn't backwards compatible when `process.env.LIBC === 'glibc'` (it will try to read `${platform}glibc-*` in that case). The solution I'm proposing here gives you the choice of including the libc flavor in your prebuild names.
2. To support https://github.com/Level/leveldown/pull/572, which is about publishing prebuilds for versioned ARM architectures, e.g. `${platform}-arm-v6`, `${platform}-arm-v7`.

cc @lgeiger @ralphtheninja @ahdinosaur 