### PR TITLE
Use process to get platform and arch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
 var path = require('path')
-var os = require('os')
 
 // Workaround to fix webpack's build warnings: 'the request of a dependency is an expression'
 var runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require // eslint-disable-line
@@ -9,8 +8,8 @@ var vars = (process.config && process.config.variables) || {}
 var prebuildsOnly = !!process.env.PREBUILDS_ONLY
 var abi = process.versions.modules // TODO: support old node where this is undef
 var runtime = isElectron() ? 'electron' : 'node'
-var arch = os.arch()
-var platform = os.platform()
+var arch = process.arch
+var platform = process.platform
 var libc = process.env.LIBC || (isAlpine(platform) ? 'musl' : 'glibc')
 var armv = process.env.ARM_VERSION || (arch === 'arm64' ? '8' : vars.arm_version) || ''
 var uv = (process.versions.uv || '').split('.')[0]


### PR DESCRIPTION
I have been doing some testing with bun, which recently added NAPI support, and it turns out that node-gyp-build works pretty well with it with minimal adjustment!
Currently [bun doesn't have a compliant 'os' module (although will soon)](https://github.com/Jarred-Sumner/bun/issues/173) , and so this change is the one thing for compatibility with bun, and seems slightly simpler, with one less require. Again, probably will be fixed on bun side, so not a big deal if you don't want this.