### PR TITLE
Prefer usage of `npm_config_target` and `npm_config_runtime`

### DIFF
--- a/node-gyp-build.js
+++ b/node-gyp-build.js
@@ -8,7 +8,6 @@ var runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_r
 
 var vars = (process.config && process.config.variables) || {}
 var prebuildsOnly = !!process.env.PREBUILDS_ONLY
-var abi = process.versions.modules // TODO: support old node where this is undef
 var runtime = isElectron() ? 'electron' : (isNwjs() ? 'node-webkit' : 'node')
 var abi = process.env.npm_config_target ? nodeAbi.getAbi(process.env.npm_config_target, runtime) : process.versions.modules // TODO: support old node where this is undef
 

--- a/node-gyp-build.js
+++ b/node-gyp-build.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 var os = require('os')
+var nodeAbi = require("node-abi")
 
 // Workaround to fix webpack's build warnings: 'the request of a dependency is an expression'
 var runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require // eslint-disable-line
@@ -9,6 +10,7 @@ var vars = (process.config && process.config.variables) || {}
 var prebuildsOnly = !!process.env.PREBUILDS_ONLY
 var abi = process.versions.modules // TODO: support old node where this is undef
 var runtime = isElectron() ? 'electron' : (isNwjs() ? 'node-webkit' : 'node')
+var abi = process.env.npm_config_target ? nodeAbi.getAbi(process.env.npm_config_target, runtime) : process.versions.modules // TODO: support old node where this is undef
 
 var arch = process.env.npm_config_arch || os.arch()
 var platform = process.env.npm_config_platform || os.platform()
@@ -44,6 +46,7 @@ load.resolve = load.path = function (dir) {
   var nearby = resolve(path.dirname(process.execPath))
   if (nearby) return nearby
 
+  var electronVersion = runtime === "electron" && process.env.npm_config_target ? process.env.npm_config_target : process.versions.electron;  
   var target = [
     'platform=' + platform,
     'arch=' + arch,
@@ -53,7 +56,7 @@ load.resolve = load.path = function (dir) {
     armv ? 'armv=' + armv : '',
     'libc=' + libc,
     'node=' + process.versions.node,
-    process.versions.electron ? 'electron=' + process.versions.electron : '',
+    electronVersion ? 'electron=' + electronVersion : '',
     typeof __webpack_require__ === 'function' ? 'webpack=true' : '' // eslint-disable-line
   ].filter(Boolean).join(' ')
 
@@ -188,6 +191,7 @@ function isNwjs () {
 }
 
 function isElectron () {
+  if (process.env.npm_config_runtime === "electron") return true
   if (process.versions && process.versions.electron) return true
   if (process.env.ELECTRON_RUN_AS_NODE) return true
   return typeof window !== 'undefined' && window.process && window.process.type === 'renderer'

--- a/node-gyp-build.js
+++ b/node-gyp-build.js
@@ -45,7 +45,9 @@ load.resolve = load.path = function (dir) {
   var nearby = resolve(path.dirname(process.execPath))
   if (nearby) return nearby
 
-  var electronVersion = runtime === "electron" && process.env.npm_config_target ? process.env.npm_config_target : process.versions.electron;  
+  var nodeVersion = runtime !== "electron" && process.env.npm_config_target ? process.env.npm_config_target : process.versions.node
+  var electronVersion = runtime === "electron" && process.env.npm_config_target ? process.env.npm_config_target : process.versions.electron
+  
   var target = [
     'platform=' + platform,
     'arch=' + arch,
@@ -54,7 +56,7 @@ load.resolve = load.path = function (dir) {
     'uv=' + uv,
     armv ? 'armv=' + armv : '',
     'libc=' + libc,
-    'node=' + process.versions.node,
+    'node=' + nodeVersion,
     electronVersion ? 'electron=' + electronVersion : '',
     typeof __webpack_require__ === 'function' ? 'webpack=true' : '' // eslint-disable-line
   ].filter(Boolean).join(' ')

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
       "default": "os"
     }
   },
+  "dependencies": {
+    "node-abi": "^3.71.0"
+  },
   "devDependencies": {
     "array-shuffle": "^1.0.1",
     "standard": "^14.0.0",


### PR DESCRIPTION
This PR addresses a similar problem that was acknowledged by https://github.com/prebuild/node-gyp-build/pull/46 a few years ago, and which I raised a few months back, https://github.com/prebuild/node-gyp-build/issues/78.

The issue is that `node-gyp-build` doesn't acknowledge the use of standardized `npm_config_*` [variables](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules#using-npm), and instead relies on values like `process.versions.module` and `process.versions.electron` which are not easily configurable as they are read-only.

This PR does two things:
- Allows the `runtime` to be set to `"electron"` if `process.env.npm_config_runtime` is equal to `"electron"`.
- Computes the correct `abi` if an explicit `process.env.npm_config_target` is defined (`"electron"`, `"node"`, and `"node-webkit"` are already valid values that can be passed to `nodeAbi.getAbi` to determine the abi).

I'm not sure if there are design reasons you have to keep things the way they are, but please let me know. Also happy to adjust the PR if you'd prefer to have this issue solved in a different way. `process.versions.node` is still preferred over `process.env.npm_config_target`, for example, as I wanted to limit the scope to address my earlier Github issue.

Thank you!