### PR TITLE
Add support for x86_64-pc-windows-gnu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,35 @@ jobs:
         run: npm install
       - name: Test
         run: npm test
+  test-msys2:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    env:
+      MSYSTEM: UCRT64
+      CHERE_INVOKING: 1
+      MSYS2_PATH_TYPE: inherit
+    strategy:
+      matrix:
+        node: [ 24 ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          install: jq base-devel binutils git mingw-w64-ucrt-x86_64-toolchain
+          pacboy: >-
+            yarn:p
+          update: true
+          path-type: inherit
+          release: false
+      - name: Install
+        run: npm install
+      - name: Test
+        run: npm test

--- a/bin.js
+++ b/bin.js
@@ -3,6 +3,7 @@
 var proc = require('child_process')
 var os = require('os')
 var path = require('path')
+var isMingw = os.type().startsWith('MINGW32_NT')
 
 if (!buildFromSource()) {
   proc.exec('node-gyp-build-test', function (err, stdout, stderr) {
@@ -21,10 +22,10 @@ function build () {
   var args = [win32 ? 'node-gyp.cmd' : 'node-gyp', 'rebuild']
 
   try {
-    var pkg = require('node-gyp/package.json')
+    var pkg = isMingw ? require(path.join(path.dirname(process.execPath), '../lib/node_modules/npm/node_modules/node-gyp/package.json')) : require('node-gyp/package.json')
     args = [
       process.execPath,
-      path.join(require.resolve('node-gyp/package.json'), '..', typeof pkg.bin === 'string' ? pkg.bin : pkg.bin['node-gyp']),
+      path.join(isMingw ? path.join(path.dirname(process.execPath), '../lib/node_modules/npm/node_modules/node-gyp') : path.join(require.resolve('node-gyp/package.json'), '..'), typeof pkg.bin === 'string' ? pkg.bin : pkg.bin['node-gyp']),
       'rebuild'
     ]
     shell = false

--- a/node-gyp-build.js
+++ b/node-gyp-build.js
@@ -15,6 +15,7 @@ var platform = process.env.npm_config_platform || os.platform()
 var libc = process.env.LIBC || (isAlpine(platform) ? 'musl' : 'glibc')
 var armv = process.env.ARM_VERSION || (arch === 'arm64' ? '8' : vars.arm_version) || ''
 var uv = (process.versions.uv || '').split('.')[0]
+var isMingw = os.type().startsWith('MINGW32_NT')
 
 module.exports = load
 
@@ -158,7 +159,7 @@ function matchTags (runtime, abi) {
     if (tags.abi && tags.abi !== abi && !tags.napi) return false
     if (tags.uv && tags.uv !== uv) return false
     if (tags.armv && tags.armv !== armv) return false
-    if (tags.libc && tags.libc !== libc) return false
+    if (tags.libc && (tags.libc !== libc || (platform === 'win32' && !isMingw))) return false
 
     return true
   }

--- a/test.js
+++ b/test.js
@@ -34,6 +34,14 @@ test('parse tags', function (t) {
     specificity: 5
   })
 
+  t.same(parseTags('node.abi64.uv1.glibc.node'), {
+    file: 'node.abi64.uv1.glibc.node',
+    runtime: 'node',
+    abi: '64',
+    uv: '1',
+    libc: 'glibc',
+    specificity: 4
+  })
   t.end()
 })
 


### PR DESCRIPTION
When compiling C++ projects using MinGW node-gyp on Windows, node-gyp utilizes the GNU toolchain (make/gcc) instead of the MSVC toolchain.